### PR TITLE
Feature: Override Contentful Environment

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -24,7 +24,7 @@ Usage:
   dato environment destroy <environmentId> [--token=<apiToken>] [--cmaBaseUrl=<url>]
   dato maintenance (on|off) [--force] [--token=<apiToken>] [--cmaBaseUrl=<url>]
   dato wp-import --token=<datoApiToken> [--environment=<datoEnvironment>] --wpUrl=<url> --wpUser=<user> --wpPassword=<password> [--datoCmaBaseUrl=<url>]
-  dato contentful-import --datoCmsToken=<apiToken> --contentfulToken=<apiToken> --contentfulSpaceId=<spaceId> [--datoCmsEnvironment=<datoEnvironment>] [--skipContent] [--datoCmaBaseUrl=<url>] [(--includeOnly <contentType>...)]
+  dato contentful-import --datoCmsToken=<apiToken> --contentfulToken=<apiToken> --contentfulSpaceId=<spaceId> [--contentfulEnvironment=<contentfulEnvironment>] [--datoCmsEnvironment=<datoEnvironment>] [--skipContent] [--datoCmaBaseUrl=<url>] [(--includeOnly <contentType>...)]
   dato check
   dato -h | --help
   dato --version
@@ -134,6 +134,7 @@ module.exports = argv => {
     const {
       '--contentfulToken': contentfulToken,
       '--contentfulSpaceId': contentfulSpaceId,
+      '--contentfulEnvironment': contentfulEnvironment,
       '--datoCmsToken': datoCmsToken,
       '--datoCmsEnvironment': datoCmsEnvironment,
       '--skipContent': skipContent,
@@ -145,6 +146,7 @@ module.exports = argv => {
     return contentfulImport({
       contentfulToken,
       contentfulSpaceId,
+      contentfulEnvironment || 'master',
       datoCmsCmaBaseUrl,
       datoCmsToken,
       datoCmsEnvironment,

--- a/src/cli.js
+++ b/src/cli.js
@@ -146,7 +146,7 @@ module.exports = argv => {
     return contentfulImport({
       contentfulToken,
       contentfulSpaceId,
-      contentfulEnvironment || 'master',
+      contentfulEnvironment,
       datoCmsCmaBaseUrl,
       datoCmsToken,
       datoCmsEnvironment,

--- a/src/contentfulImport/command.js
+++ b/src/contentfulImport/command.js
@@ -15,6 +15,7 @@ import publishRecords from './publishRecords';
 export default async ({
   contentfulToken,
   contentfulSpaceId,
+  contentfulEnvironment,
   datoCmsToken,
   datoCmsEnvironment,
   datoCmsCmaBaseUrl,
@@ -33,6 +34,7 @@ export default async ({
     client: client.contentful,
     skipContent,
     contentType,
+    contentfulEnvironment || 'master'
   });
 
   await removeAllValidators({ datoClient, contentfulData });

--- a/src/contentfulImport/command.js
+++ b/src/contentfulImport/command.js
@@ -34,7 +34,7 @@ export default async ({
     client: client.contentful,
     skipContent,
     contentType,
-    contentfulEnvironment || 'master'
+    contentfulEnvironment
   });
 
   await removeAllValidators({ datoClient, contentfulData });

--- a/src/contentfulImport/getContentfulData.js
+++ b/src/contentfulImport/getContentfulData.js
@@ -23,10 +23,10 @@ async function allPages(apiCall) {
   return items;
 }
 
-export default async ({ client, skipContent, contentType }) => {
+export default async ({ client, skipContent, contentType, contentfulEnvironment }) => {
   const spinner = ora('Downloading Contentful data structure').start();
   const environments = await client.getEnvironments();
-  const environment = environments.items.find(e => e.name === 'master');
+  const environment = environments.items.find(e => e.name === (contentfulEnvironment || 'master'));
   const rawLocales = await environment.getLocales();
   const defaultLocale = rawLocales.items.find(locale => locale.default).code;
   const locales = rawLocales.items.map(locale => locale.code);


### PR DESCRIPTION
Sometimes, when a user is performing a migration from Contentful to Dato, they need to specify a custom environment in *Contentful*, not just in Dato. This PR adds support for a flag to do just that.